### PR TITLE
Bugfix/use client id in consents service

### DIFF
--- a/examples/cv/api/services/consents.js
+++ b/examples/cv/api/services/consents.js
@@ -1,11 +1,9 @@
-const operator = require('../adapters/operator')
-
 const area = 'cv'
 
 const defaultRequest = {
   scope: [
     {
-      domain: operator.config.clientId,
+      domain: process.env.CLIENT_ID,
       area,
       description: 'A list of your work experiences, educations, language proficiencies and so on that you have entered in the service.',
       permissions: [ 'write' ],
@@ -20,7 +18,7 @@ const addExpiry = now => obj => durationInSeconds => Object.assign({}, obj, { ex
 module.exports = {
   createDefaultRequest: addExpiry(Date.now)(defaultRequest),
   area,
-  domain: operator.config.clientId,
+  domain: process.env.CLIENT_ID,
   addExpiry // Exposed for testing purposes
 }
 

--- a/examples/cv/api/services/consents.js
+++ b/examples/cv/api/services/consents.js
@@ -1,11 +1,11 @@
+const operator = require('../adapters/operator')
 
-const domain = 'localhost:4000'
 const area = 'cv'
 
 const defaultRequest = {
   scope: [
     {
-      domain,
+      domain: operator.config.clientId,
       area,
       description: 'A list of your work experiences, educations, language proficiencies and so on that you have entered in the service.',
       permissions: [ 'write' ],
@@ -20,7 +20,7 @@ const addExpiry = now => obj => durationInSeconds => Object.assign({}, obj, { ex
 module.exports = {
   createDefaultRequest: addExpiry(Date.now)(defaultRequest),
   area,
-  domain,
+  domain: operator.config.clientId,
   addExpiry // Exposed for testing purposes
 }
 

--- a/infrastructure/openshift/test/cv-DeploymentConfig.yml
+++ b/infrastructure/openshift/test/cv-DeploymentConfig.yml
@@ -52,7 +52,7 @@ spec:
           - name: REDIS
             value: 'redis://:fubar@redis-test.my-data.svc:6379/'
           - name: CLIENT_ID
-            value: cv-test.dev.services.jtech.se
+            value: https://cv-test.dev.services.jtech.se
           image: cv:test
           imagePullPolicy: Always
           name: cv-test


### PR DESCRIPTION
This bug causes the CV data to always be saved in a folder called localhost:4000 in the PDS.