### PR TITLE
Add test-all script for running all unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "update-all": "npm i && npm --prefix ./app i ./app && npm --prefix ./client i ./client && npm --prefix ./examples/cv i ./examples/cv && npm --prefix ./operator i ./operator && npm --prefix ./e2e i ./e2e ",
     "audit-all": "npm audit && npm --prefix ./app audit && npm --prefix ./client audit && npm --prefix ./examples/cv audit && npm --prefix ./operator audit && npm --prefix ./e2e audit ",
     "audit-fix-all": "npm audit fix && npm --prefix ./app audit fix && npm --prefix ./client audit fix && npm --prefix ./examples/cv audit fix && npm --prefix ./operator audit fix && npm --prefix ./e2e audit fix",
+    "test-all": "npm --prefix ./app test ./app && npm --prefix ./client test ./client && npm --prefix ./examples/cv test ./examples/cv && npm --prefix ./operator test ./operator",
     "test": "sh -c 'cd ./e2e && ./script.sh'"
   },
   "dependencies": {},


### PR DESCRIPTION
In Project root:
`npm run test-all` runs unit tests in all subprojects
`npm test` runs system-wide e2e/integration tests