### PR TITLE
Use same node version in app/Dockerfile as .nvmrc

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.5
+FROM node:11.9.0
 
 WORKDIR /app
 


### PR DESCRIPTION
10.5 does not work for the e2e flow.
Should use same version as in .nvmrc