### PR TITLE
add explicit returns for keyProvider save methods

### DIFF
--- a/client/lib/keyProvider.js
+++ b/client/lib/keyProvider.js
@@ -89,14 +89,14 @@ class KeyProvider {
     return key
   }
   async saveKey (key) {
-    this.save(`${KEY_PREFIX}${key.kid}`, key)
+    return this.save(`${KEY_PREFIX}${key.kid}`, key)
   }
   async removeKey (kid) {
     await this.keyValueStore.remove(`${KEY_PREFIX}${kid}`)
   }
   async saveAccessKeyIds (consentId, domain, area, keys) {
     const key = [consentId, domain, area].join('|')
-    this.save(`${ACCESS_KEY_IDS_PREFIX}${key}`, keys)
+    return this.save(`${ACCESS_KEY_IDS_PREFIX}${key}`, keys)
   }
   async getAccessKeyIds (consentId, domain, area) {
     const key = [consentId, domain, area].join('|')
@@ -111,7 +111,7 @@ class KeyProvider {
   }
   async saveDocumentKeys (consentId, domain, area, keys) {
     const key = [consentId, domain, area].join('|')
-    this.save(`${DOCUMENT_KEYS_PREFIX}${key}`, keys)
+    return this.save(`${DOCUMENT_KEYS_PREFIX}${key}`, keys)
   }
   async getDocumentKeys (consentId, domain, area) {
     const key = [consentId, domain, area].join('|')

--- a/client/lib/keyProvider.js
+++ b/client/lib/keyProvider.js
@@ -67,7 +67,7 @@ class KeyProvider {
     return value ? base64ToJson(value) : value
   }
   async save (key, value, ttl) {
-    this.keyValueStore.save(key, jsonToBase64(value), ttl)
+    return this.keyValueStore.save(key, jsonToBase64(value), ttl)
   }
   async getKey (kid) {
     if (kid === 'client_key') {


### PR DESCRIPTION
Before: Some functions did not wait for the keyStore provider to properly save data. Thus, a racecondition existed.
After: Aforementioned functions now return underlying promises for caller to react to, thus the racecondition is removed and the flow now awaits and works accordingly.