### PR TITLE
Add info about generating keys with OpenSSL

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -26,6 +26,8 @@ const config = {
 const client = create(config)
 ```
 
+[How do I generate my client keys?](#generate-a-keypair-using-openssl?)
+
 ## Provide routes
 
 ```javascript
@@ -59,3 +61,21 @@ client.events.on('CONSENT_APPROVED', consent => {
   scope: ['something']
 }
 ```
+
+## Generate a keypair using OpenSSL
+_Prerequisite:_ You will need to have [OpenSSL](http://www.openssl.org/) installed on your system.
+
+1. Generate a RSA keypair with a 2048 bit private key
+```
+$ openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+ ....................................................................+++
+ ....................................................+++
+```
+2. Extract the public key
+
+```
+$ openssl rsa -pubout -in private_key.pem -out public_key.pem
+writing RSA key
+```
+
+You will now have a suitable RSA keypair in the files `private_key.pem` and `public_key.pem`


### PR DESCRIPTION
The Readme previously lacked information about how to go about generating keys for the client