### PR TITLE
fix(app): consent-screens now handles reject-actions

### DIFF
--- a/app/lib/components/ConsentRequest.js
+++ b/app/lib/components/ConsentRequest.js
@@ -26,7 +26,8 @@ class ConsentRequest extends Component {
   }
 
   reject = () => {
-    this.setState({ modalVisible: false })
+    this.setState({ view: 'loading', modalVisible: false })
+    this.props.onCancel()
   }
 
   render() {

--- a/app/lib/components/LoginRequest.js
+++ b/app/lib/components/LoginRequest.js
@@ -69,7 +69,10 @@ function LoginRequest(props) {
     props.onError()
   }
 
-  const reject = () => {}
+  const reject = () => {
+    updateState({ ...currentState, view: 'loading' })
+    props.onCancel()
+  }
 
   switch (currentState.view) {
     case 'loading':

--- a/app/lib/screens/ConsentRequest/ConsentRequest.js
+++ b/app/lib/screens/ConsentRequest/ConsentRequest.js
@@ -19,6 +19,7 @@ class ManageConsentsRequestScreen extends React.Component {
   }
 
   onCancel = () => {
+    this.setState({ view: 'enter' })
     this.props.navigation.navigate('Hem')
   }
 
@@ -37,6 +38,7 @@ class ManageConsentsRequestScreen extends React.Component {
           <LoginRequest
             code={this.state.code}
             onApprove={this.onApprove}
+            onCancel={this.onCancel}
             onError={this.onError}
           />
         )
@@ -45,6 +47,7 @@ class ManageConsentsRequestScreen extends React.Component {
           <ConsentRequest
             consentRequestId={this.state.code}
             onApprove={this.onApprove}
+            onCancel={this.onCancel}
           />
         )
       case 'enter':


### PR DESCRIPTION
Fixes issue where screens would go into an undefined state when rejecting a login or consent-request.