### PR TITLE
chore: Make operator test use latest-tag instead of latest

### DIFF
--- a/infrastructure/openshift/test/operator-DeploymentConfig.yml
+++ b/infrastructure/openshift/test/operator-DeploymentConfig.yml
@@ -53,7 +53,7 @@ spec:
               secretKeyRef:
                 name: apm
                 key: token
-          image: jobtechswe/mydata-operator:latest
+          image: jobtechswe/mydata-operator:latest-tag
           imagePullPolicy: Always
           name: operator-test
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
Openshift config was using wrong image