### PR TITLE
chore: 🤖 init container that runs postgres migrations

### DIFF
--- a/infrastructure/openshift/ci/operator-DeploymentConfig.yml
+++ b/infrastructure/openshift/ci/operator-DeploymentConfig.yml
@@ -78,6 +78,30 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+      initContainers:
+        - env:
+          - name: NODE_ENV
+            value: production
+          - name: PGHOST
+            value: postgresql-legacy-operator.mydata.svc
+          - name: PGPORT
+            value: '5432'
+          - name: PGUSER
+            value: postgresuser
+          - name: PGPASSWORD
+            value: postgrespassword
+          - name: PGDATABASE
+            value: mydata
+          - name: DATABASE_URL
+            value: postgres://postgresuser:postgrespassword@postgresql-legacy-operator.mydata.svc:5432/mydata
+          - name: APP_NAME
+            value: legacy_operator
+          image: jobtechswe/mydata-operator:latest
+          imagePullPolicy: Always
+          name: init-legacy-operator
+          command: ['npm', 'run', 'migrate', 'up']
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/infrastructure/openshift/legacy-operator/operator-DeploymentConfig.yml
+++ b/infrastructure/openshift/legacy-operator/operator-DeploymentConfig.yml
@@ -78,6 +78,30 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+      initContainers:
+        - env:
+          - name: NODE_ENV
+            value: production
+          - name: PGHOST
+            value: postgresql-legacy-operator.mydata.svc
+          - name: PGPORT
+            value: '5432'
+          - name: PGUSER
+            value: postgresuser
+          - name: PGPASSWORD
+            value: postgrespassword
+          - name: PGDATABASE
+            value: mydata
+          - name: DATABASE_URL
+            value: postgres://postgresuser:postgrespassword@postgresql-legacy-operator.mydata.svc:5432/mydata
+          - name: APP_NAME
+            value: legacy_operator
+          image: jobtechswe/mydata-operator:0.25.2
+          imagePullPolicy: Always
+          name: init-legacy-operator
+          command: ['npm', 'run', 'migrate', 'up']
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/infrastructure/openshift/test/operator-DeploymentConfig.yml
+++ b/infrastructure/openshift/test/operator-DeploymentConfig.yml
@@ -78,6 +78,30 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+      initContainers:
+        - env:
+          - name: NODE_ENV
+            value: production
+          - name: PGHOST
+            value: postgresql-legacy-operator.mydata.svc
+          - name: PGPORT
+            value: '5432'
+          - name: PGUSER
+            value: postgresuser
+          - name: PGPASSWORD
+            value: postgrespassword
+          - name: PGDATABASE
+            value: mydata
+          - name: DATABASE_URL
+            value: postgres://postgresuser:postgrespassword@postgresql-legacy-operator.mydata.svc:5432/mydata
+          - name: APP_NAME
+            value: legacy_operator
+          image: jobtechswe/mydata-operator:latest-tag
+          imagePullPolicy: Always
+          name: init-legacy-operator
+          command: ['npm', 'run', 'migrate', 'up']
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
There does not seem to be an automated way to run postgres migrations when we deploy the `operator`.

Init container runs the migrations 