### PR TITLE
chore: improve and tidy up installation script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - if ! [ -x "$(command -v lerna)" ]; then npm install -g lerna; fi
     - sudo apt-get install libgconf-2-4
     install:
-    - npm run install
+    - npm ci
     before_script:
     - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     - chmod +x ./cc-test-reporter
@@ -50,13 +50,12 @@ jobs:
     - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
     - chmod +x docker-compose
     - sudo mv docker-compose /usr/local/bin
-    - if ! [ -x "$(command -v lerna)" ]; then npm install -g lerna; fi
     - sudo apt-get install libgconf-2-4
     install:
     - docker load -i ~/.cache/docker/node.tar || true
     - docker load -i ~/.cache/docker/redis.tar || true
     - docker load -i ~/.cache/docker/postgres.tar || true
-    - npm run install
+    - npm ci
     script:
     - npm run lint
     - npm run test:e2e

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,7 +25,9 @@
       }
     },
     "@egendata/messaging": {
-      "version": "0.3.0",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@egendata/messaging/-/messaging-0.3.1.tgz",
+      "integrity": "sha512-HHPL6ICukuTmA4hI13Sw0oLPcq48fgaNMrbq5PvEN9zF77uxryVqMNq0B4xmIRZV/KViTSDQpZwiz4vgJxxEgQ==",
       "requires": {
         "axios": "^0.18.1",
         "http-errors": "^1.7.2",
@@ -4011,6 +4013,16 @@
       "requires": {
         "merge-stream": "^1.0.1"
       }
+    },
+    "joi-browser": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-13.4.0.tgz",
+      "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
+    },
+    "js-base64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "egendata",
+  "name": "Egendata",
   "version": "0.25.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "audit": "lerna exec --parallel -- npm audit",
     "audit:fix": "lerna exec --parallel -- npm audit fix",
-    "clean": "lerna clean",
-    "install": "rm examples/cv/package-lock.json; rm examples/national-registration/package-lock.json; lerna exec -- npm i",
+    "clean": "lerna clean --yes",
+    "postinstall": "lerna exec --parallel -- npm ci",
     "lint": "lerna exec --parallel -- npm run lint",
     "start": "docker-compose -f docker-compose.dev.yml down && docker-compose down && docker-compose up -d && docker-compose -f docker-compose.dev.yml up -d",
     "test": "npm run lint && npm run test:unit && npm run test:e2e",


### PR DESCRIPTION
* remove old workaround for npm bug with local includes (which was to rm lockfiles and use `npm i` instead of `npm ci`)
* move script from `install` to `postinstall` to make it less confusing (it does the same thing)
* fix a broken lockfile in client
* remove need to confirm `npm run clean`
* make travis use `npm ci` instead of `npm run install` (removes need to install lerna globally)