### PR TITLE
feat: add 64-bit versions to gradle build

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -105,7 +105,7 @@ android {
         versionCode 6 
         versionName "1.0"
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "x86", "x86_64", "arm64-v8a"
         }
         multiDexEnabled true
         missingDimensionStrategy 'react-native-camera', 'general'


### PR DESCRIPTION
I started following this guide: https://developer.android.com/distribute/best-practices/develop/64-bit#test_your_app_on_64-bit_hardware

So far I've added 64-bit versions of the native libraries used by the app that is generated in the build.

Unsure what to do next :)